### PR TITLE
Expose groups usage java API

### DIFF
--- a/src/main/java/net/mindengine/galen/reports/GalenTestInfo.java
+++ b/src/main/java/net/mindengine/galen/reports/GalenTestInfo.java
@@ -17,6 +17,7 @@ package net.mindengine.galen.reports;
 
 import java.lang.reflect.Method;
 import java.util.Date;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -98,6 +99,10 @@ public class GalenTestInfo {
 
     public static GalenTestInfo fromString(final String name) {
         return new GalenTestInfo(name, new GalenEmptyTest(name, null));
+    }
+
+    public static GalenTestInfo fromString(final String name, final List<String> groups) {
+        return new GalenTestInfo(name, new GalenEmptyTest(name, groups));
     }
 
     public static GalenTestInfo fromMethod(Method method) {


### PR DESCRIPTION
Simple adding list of groups to GalenTestInfo:
![galen_reports](https://cloud.githubusercontent.com/assets/979121/6516737/bf2e8a8a-c394-11e4-8464-37332fda05fe.png)
see #119