### PR TITLE
CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7
+script:
+  - mvn clean install verify -Dgpg.skip=true
+before_install:
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+version: 2.0.3_build'{build}'
+os: Windows Server 2012
+environment:
+  JAVA_HOME: C:\Program Files\Java\jdk1.7.0
+install:
+  - ps: |
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+      if (!(Test-Path -Path "C:\maven" )) {
+        (new-object System.Net.WebClient).DownloadFile(
+          'http://www.us.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip',
+          'C:\maven-bin.zip'
+        )
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
+      }
+  - cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
+build_script:
+  - mvn clean package --batch-mode -DskipTest -Dgpg.skip=true
+test_script:
+  - mvn clean verify -Dgpg.skip=true
+cache:
+  - C:\maven\
+  - C:\Users\appveyor\.m2
+


### PR DESCRIPTION
I've created sample configurations for CI builds within a cloud environment:
* Travis CI (Linux based)
* AppVeyour (Windows based)

This makes it possible that Pull Request gets already validated by a build and does not depend on a personal managed Jenkins ....

*Steps to configure*

Enable Travis CI in GitHub Settings and Login to Travis CI and enable the repo

For AppVeyour also create an account and activate the project

Add the markdowns:
* ```[![Build Status](https://travis-ci.org/galenframework/galen.svg?branch=master)](https://travis-ci.org/galenframework/galen)```
* https://ci.appveyor.com/project/galenframework/galen/settings/badges
