### PR TITLE
Delete section about release branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ Contributing
 ------------
 If you want to contribute to this project just look for current open issues. Please let know in the comments of the issue that you are going to pick it up because somebody could already work on it. In the end just send the pull request. By the way the feature that you are going to work on should not just solve your particular problem. It should be extendable and configurable. The github issues is the best place to debate on the feature and discuss how it should be implemented.
 
-All the work on the next version is performed in corresponding release branch (e.g. release-2.0). The master branch reflects the current live version. Most of the pull requests are accepted on release branch and not on master. If you think it is a crucial bugfix for current version, please consider asking in developers chat first.
-
 If you would like to make a change to the Galen Framework website (http://galenframework.com) you can do it here https://github.com/galenframework/galenframework.com
 
 


### PR DESCRIPTION
The current status of the master branch suggests that commits are
going directly to master, because master is ahead of release-2.0.