### PR TITLE
Disable GPG plugin for `install` step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+install: mvn install -DskipTests -Dgpg.skip
 jdk:
   - oraclejdk8
   - oraclejdk7


### PR DESCRIPTION
Skip the GPG plugin because it needs a key for signing the artifacts but such a key is currently not available on Travis by default. (Signed artifacts are only needed for publishing to Maven Central.)