### PR TITLE
Fix test for test name.

### DIFF
--- a/galen-java-support/src/test/java/com/galenframework/junit/GalenJUnitTestBaseIT.java
+++ b/galen-java-support/src/test/java/com/galenframework/junit/GalenJUnitTestBaseIT.java
@@ -40,7 +40,7 @@ public class GalenJUnitTestBaseIT extends GalenJUnitTestBase {
     @Test
     public void shouldConcatenateClassAndMethodNameForTestName() {
         assertThat(getTestName(), is(equalTo(
-                "com.galenframework.junit.GalenJUnitTestBaseTest#>shouldConcatenateClassAndMethodNameForTestName")));
+                "com.galenframework.junit.GalenJUnitTestBaseIT#>shouldConcatenateClassAndMethodNameForTestName")));
     }
 
     @Parameters


### PR DESCRIPTION
The test name changed because the name of the test class changed in
90f4ec44517a37a1955bc9d1936e9e08b9faafb0.