### PR TITLE
Add JUnit runner for checking specs.

### DIFF
--- a/galen-java-support/src/main/java/com/galenframework/junit/Exclude.java
+++ b/galen-java-support/src/main/java/com/galenframework/junit/Exclude.java
@@ -1,0 +1,20 @@
+package com.galenframework.junit;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A list of tags for spec sections to be excluded from the filtered group.
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface Exclude {
+    /**
+     * The list of tags.
+     * @return a list of tags.
+     */
+    String[] value();
+}

--- a/galen-java-support/src/main/java/com/galenframework/junit/GalenSpecRunner.java
+++ b/galen-java-support/src/main/java/com/galenframework/junit/GalenSpecRunner.java
@@ -1,0 +1,234 @@
+package com.galenframework.junit;
+
+import com.galenframework.browser.Browser;
+import com.galenframework.browser.SeleniumBrowserFactory;
+import com.galenframework.speclang2.pagespec.SectionFilter;
+import com.galenframework.specs.page.PageSection;
+import com.galenframework.suite.GalenPageAction;
+import com.galenframework.validation.PageValidation;
+import com.galenframework.validation.ValidationListener;
+import com.galenframework.validation.ValidationResult;
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.*;
+import java.util.List;
+
+import static com.galenframework.api.Galen.checkLayout;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.junit.runner.Description.createSuiteDescription;
+import static org.junit.runner.Description.createTestDescription;
+
+/**
+ * Performs a single page test using JUnit. Have a look at the following
+ * example
+ * <pre>
+ * &#064;RunWith(GalenSpecRunner.class)
+ * &#064;Exclude("firstExclude", "secondExclude")
+ * &#064;Include("firstInclude", "secondInclude")
+ * &#064;Size(width=640, height=480)
+ * &#064;Spec("/my/package/homepage.gspec")
+ * &#064;Url("http://localhost:13728/")
+ * public void SinglePageTest {
+ *
+ * }
+ * </pre>
+ * <p>This test performs a single page test for the URL
+ * {@code http://localhost:13728/}. It starts the browser, sets its size to
+ * {@code 640x480} and verifies that the page fulfills the specification
+ * {@code homepage.spec}. It excludes the sections {@code firstExclude} and
+ * {@code secondExclude} of the specification and includes the sections
+ * {@code firstInclude} and {@code secondInclude}.
+ * <p>The annotations {@code &#064;Size}, {@code &#064;Spec} and
+ * {@code &#064;Url} are mandatory.
+ */
+public class GalenSpecRunner extends Runner {
+    private static final Map<String, Object> NO_JS_VARIABLES = emptyMap();
+    private static final Properties NO_PROPERTIES = new Properties();
+    private static final File NO_SCREENSHOT = null;
+    private static final List<String> NO_TAGS = emptyList();
+    private Class<?> testClass;
+
+    /**
+     * Constructs a new {@code GalenSpecRunner} that will run {@code testClass}.
+     *
+     * @param testClass the class with the test specification.
+     */
+    public GalenSpecRunner(Class<?> testClass) throws InitializationError {
+        this.testClass = testClass;
+    }
+
+    @Override
+    public Description getDescription() {
+        return createSuiteDescription(testClass);
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+        try {
+            Dimension windowsSize = getWindowSize();
+            String specPath = getSpecPath();
+            String pageUrl = getUrl();
+            SectionFilter sectionFilter = getSectionFilter();
+            run(notifier, windowsSize, sectionFilter, specPath, pageUrl);
+        } catch (Throwable e) {
+            Failure failure = new Failure(getDescription(), e);
+            notifier.fireTestFailure(failure);
+        }
+    }
+
+    private void run(RunNotifier notifier, Dimension windowsSize, SectionFilter sectionFilter, String specPath,
+            String pageUrl) throws IOException {
+        JUnitListener listener = new JUnitListener(notifier);
+        run(listener, windowsSize, sectionFilter, specPath, pageUrl);
+    }
+
+    private void run(JUnitListener listener, Dimension windowsSize, SectionFilter sectionFilter, String specPath,
+            String url) throws IOException {
+        Browser browser = createBrowser();
+        try {
+            browser.load(url);
+            browser.changeWindowSize(windowsSize);
+            checkLayout(browser, specPath, sectionFilter, NO_PROPERTIES, NO_JS_VARIABLES, NO_SCREENSHOT, listener);
+        } finally {
+            browser.quit();
+        }
+    }
+
+    private Browser createBrowser() {
+        return new SeleniumBrowserFactory().openBrowser();
+    }
+
+    private SectionFilter getSectionFilter() {
+        return new SectionFilter(getIncludedTags(), getExcludedTags());
+    }
+
+    private List<String> getExcludedTags() {
+        Exclude annotation = testClass.getAnnotation(Exclude.class);
+        return annotation == null ? NO_TAGS : asList(annotation.value());
+    }
+
+    private List<String> getIncludedTags() {
+        Include annotation = testClass.getAnnotation(Include.class);
+        return annotation == null ? NO_TAGS : asList(annotation.value());
+    }
+
+    private String getSpecPath() {
+        return getMandatoryAnnotation(Spec.class).value();
+    }
+
+    private String getUrl() {
+        return getMandatoryAnnotation(Url.class).value();
+    }
+
+    private Dimension getWindowSize() {
+        Size size = getMandatoryAnnotation(Size.class);
+        return new Dimension(size.width(), size.height());
+    }
+
+    private <A extends Annotation> A getMandatoryAnnotation(Class<A> annotationType) {
+        A annotation = testClass.getAnnotation(annotationType);
+        if (annotation == null) {
+            throw new IllegalStateException("The annotation @"
+                    + annotationType.getSimpleName() + " is missing.");
+        } else {
+            return annotation;
+        }
+    }
+
+    private static class JUnitListener implements ValidationListener {
+        private final RunNotifier runNotifier;
+
+        public JUnitListener(RunNotifier runNotifier) {
+            this.runNotifier = runNotifier;
+        }
+
+        @Override
+        public void onObject(PageValidation pageValidation, String objectName) {
+
+        }
+
+        @Override
+        public void onAfterObject(PageValidation pageValidation, String objectName) {
+
+        }
+
+        @Override
+        public void onBeforeSpec(PageValidation pageValidation, String objectName, com.galenframework.specs.Spec spec) {
+            Description description = createDescriptionForSpec(objectName, spec);
+            runNotifier.fireTestStarted(description);
+        }
+
+        @Override
+        public void onSpecError(PageValidation pageValidation, String objectName, com.galenframework.specs.Spec spec, ValidationResult validationResult) {
+            Description description = createDescriptionForSpec(objectName, spec);
+            Failure failure = new Failure(description, new AssertionError(validationResult.getError().getMessages()));
+            runNotifier.fireTestFailure(failure);
+            runNotifier.fireTestFinished(description);
+        }
+
+        @Override
+        public void onSpecSuccess(PageValidation pageValidation, String objectName, com.galenframework.specs.Spec spec, ValidationResult validationResult) {
+            Description description = createDescriptionForSpec(objectName, spec);
+            runNotifier.fireTestFinished(description);
+        }
+
+        private Description createDescriptionForSpec(String objectName, com.galenframework.specs.Spec spec) {
+            return createTestDescription(objectName, spec.getOriginalText());
+        }
+
+        @Override
+        public void onGlobalError(Exception e) {
+
+        }
+
+        @Override
+        public void onBeforePageAction(GalenPageAction action) {
+
+        }
+
+        @Override
+        public void onAfterPageAction(GalenPageAction action) {
+
+        }
+
+        @Override
+        public void onBeforeSection(PageValidation pageValidation, PageSection pageSection) {
+
+        }
+
+        @Override
+        public void onAfterSection(PageValidation pageValidation, PageSection pageSection) {
+
+        }
+
+        @Override
+        public void onSubLayout(PageValidation pageValidation, String objectName) {
+
+        }
+
+        @Override
+        public void onAfterSubLayout(PageValidation pageValidation, String objectName) {
+
+        }
+
+        @Override
+        public void onSpecGroup(PageValidation pageValidation, String specGroupName) {
+
+        }
+
+        @Override
+        public void onAfterSpecGroup(PageValidation pageValidation, String specGroupName) {
+
+        }
+    }
+}

--- a/galen-java-support/src/main/java/com/galenframework/junit/Include.java
+++ b/galen-java-support/src/main/java/com/galenframework/junit/Include.java
@@ -1,0 +1,20 @@
+package com.galenframework.junit;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A list of tags for spec sections which will be included in testing.
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface Include {
+    /**
+     * The list of tags.
+     * @return a list of tags.
+     */
+    String[] value();
+}

--- a/galen-java-support/src/main/java/com/galenframework/junit/Size.java
+++ b/galen-java-support/src/main/java/com/galenframework/junit/Size.java
@@ -1,0 +1,26 @@
+package com.galenframework.junit;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Dimensions of browser window.
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface Size {
+    /**
+     * The height of the browser window.
+     * @return the height of the browser window.
+     */
+    int height();
+
+    /**
+     * The width of the browser window.
+     * @return the width of the browser window.
+     */
+    int width();
+}

--- a/galen-java-support/src/main/java/com/galenframework/junit/Spec.java
+++ b/galen-java-support/src/main/java/com/galenframework/junit/Spec.java
@@ -1,0 +1,16 @@
+package com.galenframework.junit;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The Galen specification file.
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface Spec {
+    String value();
+}

--- a/galen-java-support/src/main/java/com/galenframework/junit/Url.java
+++ b/galen-java-support/src/main/java/com/galenframework/junit/Url.java
@@ -1,0 +1,16 @@
+package com.galenframework.junit;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A URL of page for Galen to test on
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface Url {
+    String value();
+}

--- a/galen-java-support/src/test/java/com/galenframework/junit/GalenSpecRunnerIT.java
+++ b/galen-java-support/src/test/java/com/galenframework/junit/GalenSpecRunnerIT.java
@@ -1,0 +1,188 @@
+package com.galenframework.junit;
+
+import org.hamcrest.Matcher;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.Failure;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.delete;
+import static java.nio.file.Files.write;
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assume.assumeTrue;
+
+public class GalenSpecRunnerIT {
+    private static final String HTML_FILE = "/tmp/GalsenSpecRunnerIT.html";
+
+    @BeforeClass
+    public static void createHtmlFile() throws IOException {
+        if (existsTmpFolder()) {
+            write(Paths.get(HTML_FILE),
+                    asList("<!DOCTYPE html>",
+                            "<html>",
+                            "<head>",
+                            "</head>",
+                            "<body>",
+                            "<p id=\"p1\" style=\"width:400px;float:left;\">First paragraph.</p>",
+                            "<p id=\"p2\">Second paragraph.</p>",
+                            "</body>",
+                            "</html>"),
+                    UTF_8);
+        }
+    }
+
+    @AfterClass
+    public static void deleteHtmlFile() throws IOException {
+        if (existsTmpFolder()) {
+            delete(Paths.get(HTML_FILE));
+        }
+    }
+
+    @Rule
+    public final ErrorCollector collector = new ErrorCollector();
+
+    @RunWith(GalenSpecRunner.class)
+    @Size(width = 640, height = 480)
+    @Spec("/com/galenframework/junit/homepage_small.gspec")
+    @Url("file://" + HTML_FILE)
+    public static class ValidSpec {
+    }
+
+    @Test
+    public void shouldBeSuccessfulForValidSpec() {
+        assumeTrue(existsTmpFolder());
+        Result result = runTest(ValidSpec.class);
+        //We use an error collector because running a test for each assertion takes too much time.
+        collector.checkThat("is successful", result.wasSuccessful(), is(true));
+        collector.checkThat("has no failures", result.getFailures(), is(empty()));
+        collector.checkThat("has a test for each spec", result.getRunCount(), is(4));
+    }
+
+    @RunWith(GalenSpecRunner.class)
+    @Size(width = 640, height = 480)
+    @Spec("/com/galenframework/junit/inapplicable.gspec")
+    @Url("file://" + HTML_FILE)
+    public static class InapplicableSpec {
+    }
+
+    @Test
+    public void shouldFailForInapplicableSpec() {
+        assumeTrue(existsTmpFolder());
+        Result result = runTest(InapplicableSpec.class);
+        //We use an error collector because running a test for each assertion takes too much time.
+        collector.checkThat("is not successful", result.wasSuccessful(), is(false));
+        collector.checkThat("has failures", result.getFailures(), hasSize(2));
+        collector.checkThat("has only assertion errors", result.getFailures(),
+                not(hasFailureWithException(not(instanceOf(AssertionError.class)))));
+        collector.checkThat("describes failure", result.getFailures(),
+                hasFailureWithException(hasProperty("message", equalTo(
+                        "[\"first_paragraph\" width is 400px but it should be less than 10px]"))));
+        collector.checkThat("has a test for each spec", result.getRunCount(), is(3));
+    }
+
+    @RunWith(GalenSpecRunner.class)
+    @Include("variantA")
+    @Size(width = 640, height = 480)
+    @Spec("/com/galenframework/junit/tag.gspec")
+    @Url("file://" + HTML_FILE)
+    public static class ExcludeTag {
+    }
+
+    @Test
+    public void shouldNotRunTestsForSectionsThatAreExcluded() {
+        assumeTrue(existsTmpFolder());
+        Result result = runTest(ExcludeTag.class);
+        collector.checkThat("has only tests for not excluded sections", result.getRunCount(), is(3));
+    }
+
+    @RunWith(GalenSpecRunner.class)
+    @Include("variantA")
+    @Exclude("variantB")
+    @Size(width = 640, height = 480)
+    @Spec("/com/galenframework/junit/tag.gspec")
+    @Url("file://" + HTML_FILE)
+    public static class IncludeTag {
+    }
+
+    @Test
+    public void shouldOnlyRunTestsForSectionsThatAreIncluded() {
+        assumeTrue(existsTmpFolder());
+        Result result = runTest(IncludeTag.class);
+        collector.checkThat("has only tests for included sections", result.getRunCount(), is(2));
+    }
+
+    @RunWith(GalenSpecRunner.class)
+    @Spec("/com/galenframework/junit/homepage_small.gspec")
+    @Url("file://" + HTML_FILE)
+    public static class NoSizeAnnotation {
+    }
+
+    @Test
+    public void shouldProvideHelpfulMessageIfSizeAnnotationsAreMissing() {
+        Result result = runTest(com.galenframework.junit.GalenSpecRunnerIT.NoSizeAnnotation.class);
+        //We use an error collector because running a test for each assertion takes too much time.
+        collector.checkThat("is successful", result.wasSuccessful(), is(false));
+        collector.checkThat("has failure", result.getFailures(), hasSize(1));
+        collector.checkThat("describes failure", result.getFailures(),
+                hasFailureWithException(hasProperty("message",
+                        equalTo("The annotation @Size is missing."))));
+    }
+
+    @RunWith(GalenSpecRunner.class)
+    @Size(width = 640, height = 480)
+    @Url("file://" + HTML_FILE)
+    public static class NoSpecAnnotation {
+    }
+
+    @Test
+    public void shouldProvideHelpfulMessageIfSpecAnnotationIsMissing() {
+        Result result = runTest(NoSpecAnnotation.class);
+        //We use an error collector because running a test for each assertion takes too much time.
+        collector.checkThat("is successful", result.wasSuccessful(), is(false));
+        collector.checkThat("has failure", result.getFailures(), hasSize(1));
+        collector.checkThat("describes failure", result.getFailures(),
+                hasFailureWithException(hasProperty("message",
+                        equalTo("The annotation @Spec is missing."))));
+    }
+
+    @RunWith(GalenSpecRunner.class)
+    @Size(width = 640, height = 480)
+    @Spec("/com/galenframework/junit/homepage_small.gspec")
+    public static class NoUrlAnnotation {
+    }
+
+    @Test
+    public void shouldProvideHelpfulMessageIfUrlAnnotationIsMissing() {
+        Result result = runTest(NoUrlAnnotation.class);
+        //We use an error collector because running a test for each assertion takes too much time.
+        collector.checkThat("is successful", result.wasSuccessful(), is(false));
+        collector.checkThat("has failure", result.getFailures(), hasSize(1));
+        collector.checkThat("describes failure", result.getFailures(),
+                hasFailureWithException(hasProperty("message",
+                        equalTo("The annotation @Url is missing."))));
+    }
+
+    private Matcher<Iterable<? super Failure>> hasFailureWithException(Matcher<?> matcher) {
+        return hasItem(hasProperty("exception", matcher));
+    }
+
+    private Result runTest(Class<?> test) {
+        return JUnitCore.runClasses(test);
+    }
+
+    private static boolean existsTmpFolder() {
+        File tmpFolder = new File("/tmp");
+        return tmpFolder.exists();
+    }
+}

--- a/galen-java-support/src/test/resources/com/galenframework/junit/homepage_small.gspec
+++ b/galen-java-support/src/test/resources/com/galenframework/junit/homepage_small.gspec
@@ -1,0 +1,12 @@
+@objects
+    first_paragraph     id    p1
+    second_paragraph    id    p2
+
+= Main section =
+    first_paragraph:
+        height > 10 px
+        width < 1000 px
+
+    second_paragraph:
+        height > 10 px
+        width < 1000 px

--- a/galen-java-support/src/test/resources/com/galenframework/junit/inapplicable.gspec
+++ b/galen-java-support/src/test/resources/com/galenframework/junit/inapplicable.gspec
@@ -1,0 +1,8 @@
+@objects
+    first_paragraph    id    p1
+
+= Main section =
+    first_paragraph:
+        width < 10 px
+        width > 2000 px
+        width > 20 px

--- a/galen-java-support/src/test/resources/com/galenframework/junit/tag.gspec
+++ b/galen-java-support/src/test/resources/com/galenframework/junit/tag.gspec
@@ -1,0 +1,17 @@
+@objects
+    first_paragraph     id    p1
+    second_paragraph    id    p2
+
+= Main section =
+
+    @on *
+        first_paragraph:
+            height > 10 px
+
+    @on variantA
+        first_paragraph:
+            width < 1000 px
+
+    @on variantA, variantB
+        second_paragraph:
+            height > 10 px


### PR DESCRIPTION
This runner makes it possible to use a JUnit test for a single page
test. A spec file is assigned to a test class. Every object spec of
this file is treated as a single test. This automatically provides
JUnit test formatting in IDEs, build tools and CI servers. E.g.
you get a test tree in IntelliJ idea that looks like this

![opu3st6-2](https://cloud.githubusercontent.com/assets/711349/13476992/9ef33f0a-e0ca-11e5-869f-dac71f29a0d7.png)

This makes it very easy to spot errors.