### PR TITLE
Fix Encoding issue

### DIFF
--- a/galen-core/src/main/java/com/galenframework/validation/specs/SpecValidationText.java
+++ b/galen-core/src/main/java/com/galenframework/validation/specs/SpecValidationText.java
@@ -37,10 +37,10 @@ public class SpecValidationText<T extends SpecText> extends SpecValidation<T> {
         
         Rect area = mainObject.getArea();
         String realText = mainObject.getText();
-        realText = new String(realText.getBytes(Charset.forName("utf-8")));
         if (realText == null) {
             realText = "";
         }
+        realText = new String(realText.getBytes(Charset.forName("utf-8")));
 
         realText = applyOperationsTo(realText, spec.getOperations());
         checkValue(spec, objectName, realText, "text", area);

--- a/galen-core/src/main/java/com/galenframework/validation/specs/SpecValidationText.java
+++ b/galen-core/src/main/java/com/galenframework/validation/specs/SpecValidationText.java
@@ -23,6 +23,7 @@ import com.galenframework.specs.SpecText;
 import com.galenframework.validation.*;
 import com.galenframework.page.PageElement;
 
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -39,6 +40,7 @@ public class SpecValidationText<T extends SpecText> extends SpecValidation<T> {
         if (realText == null) {
             realText = "";
         }
+        realText = new String(realText.getBytes(Charset.forName("utf-8")));
 
         realText = applyOperationsTo(realText, spec.getOperations());
         checkValue(spec, objectName, realText, "text", area);

--- a/galen-core/src/main/java/com/galenframework/validation/specs/SpecValidationText.java
+++ b/galen-core/src/main/java/com/galenframework/validation/specs/SpecValidationText.java
@@ -37,10 +37,10 @@ public class SpecValidationText<T extends SpecText> extends SpecValidation<T> {
         
         Rect area = mainObject.getArea();
         String realText = mainObject.getText();
+        realText = new String(realText.getBytes(Charset.forName("utf-8")));
         if (realText == null) {
             realText = "";
         }
-        realText = new String(realText.getBytes(Charset.forName("utf-8")));
 
         realText = applyOperationsTo(realText, spec.getOperations());
         checkValue(spec, objectName, realText, "text", area);

--- a/galen-core/src/main/resources/html-report/report-test.tpl.html
+++ b/galen-core/src/main/resources/html-report/report-test.tpl.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <title>Galen Reports</title>
+        <meta charset="utf-8" />
         <link rel="stylesheet" type="text/css" href="report.css"></link>
         <script src="jquery-1.11.2.min.js"></script>
         <script src="handlebars-v2.0.0.js"></script>

--- a/galen-core/src/main/resources/html-report/report.tpl.html
+++ b/galen-core/src/main/resources/html-report/report.tpl.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <title>Galen Reports</title>
+        <meta charset="utf-8" />
         <link rel="stylesheet" type="text/css" href="report.css"></link>
         <link rel="stylesheet" type="text/css" href="tablesorter.css"></link>
         <script src="jquery-1.11.2.min.js"></script>


### PR DESCRIPTION
Fixed encoding issue unable to check cyrillic symbols in Windows using UTF-8 gspec (selenium gets string in wrong encoding).
Also fixed cyrillic and other symbols displaying in Report.