### PR TITLE
Corrections are added to Locator objects when copy on multi object specs

### DIFF
--- a/galen-core/src/main/java/com/galenframework/speclang2/pagespec/ObjectDefinitionProcessor.java
+++ b/galen-core/src/main/java/com/galenframework/speclang2/pagespec/ObjectDefinitionProcessor.java
@@ -146,7 +146,7 @@ public class ObjectDefinitionProcessor {
 
         for (int index = 1; index <= count; index++) {
             addObjectToSpec(objectNode, objectName.replace("*", Integer.toString(index)),
-                    new Locator(locator.getLocatorType(), locator.getLocatorValue(), index).withParent(locator.getParent()),
+                    new Locator(locator.getLocatorType(), locator.getLocatorValue(), index).withParent(locator.getParent()).withCorrections(locator.getCorrections()),
                     groupsForThisObject);
         }
     }


### PR DESCRIPTION
It looks like Corrections is not copied to new Locator object on multi object copy process.   
I am expecting this code is going to fix that bug https://github.com/galenframework/galen/issues/526 .